### PR TITLE
Add release token override

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,15 +147,17 @@ The action creates a new release with CalVer versioning, and you can optionally 
 
 > [!IMPORTANT]
 > The `secrets.GITHUB_TOKEN` variable is automatically populated (see [docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)).
-> However, releases created using `GITHUB_TOKEN` will not trigger other workflows that run on the `release` event.
-> If you need to trigger other workflows when a release is created, you'll need to:
-> 1. Create a Personal Access Token (PAT) with `contents: write` permissions at https://github.com/settings/tokens
-> 2. Add it to your repository secrets (e.g., as `PAT`)
-> 3. Use it in the workflow:
+> It is enough when this action only needs to create a tag/release, or when later publish steps run in the same workflow job.
+> However, tags and releases created using `GITHUB_TOKEN` will not trigger other workflows that run on `push`, `create`, or `release` events.
+> If you need downstream workflows to run when a tag or release is created, you'll need to:
+> 1. Create a Personal Access Token (PAT) with `contents: write` permissions at https://github.com/settings/tokens, or create an equivalent GitHub App token.
+> 2. Add it to your repository secrets (e.g., as `RELEASE_TOKEN`).
+> 3. Pass it as `release_token`:
 >    ```yaml
 >    - uses: basnijholt/calver-auto-release@v1
 >      with:
->        github_token: ${{ secrets.PAT }}  # Instead of secrets.GITHUB_TOKEN
+>        github_token: ${{ secrets.GITHUB_TOKEN }}
+>        release_token: ${{ secrets.RELEASE_TOKEN }}
 >    ```
 
 ### CLI Usage

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,12 @@ name: "CalVer Auto Release"
 description: "Automatically create GitHub releases using Calendar Versioning (CalVer)"
 inputs:
   github_token:
-    description: "GitHub token for creating releases"
+    description: "GitHub token for pushing release tags and creating releases"
     required: true
+  release_token:
+    description: "Optional token to use for pushing release tags and creating releases; use a PAT or GitHub App token when downstream workflows must run from release/tag events"
+    required: false
+    default: ""
   skip_patterns:
     description: "Comma-separated list of patterns to skip releases"
     required: false
@@ -44,7 +48,7 @@ runs:
     - name: Configure Git
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.release_token || inputs.github_token }}
       run: |
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@users.noreply.github.com"
@@ -87,4 +91,4 @@ runs:
         generate_release_notes: ${{ inputs.release_notes_type == 'github' }}
         body: ${{ inputs.release_notes_type == 'tag_message' && steps.tag_message.outputs.content || '' }}
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.release_token || inputs.github_token }}

--- a/tests/test_action_integration.py
+++ b/tests/test_action_integration.py
@@ -24,6 +24,8 @@ def test_action_yml_structure() -> None:
     # Verify inputs
     assert "github_token" in action["inputs"]
     assert action["inputs"]["github_token"]["required"] is True
+    assert "release_token" in action["inputs"]
+    assert action["inputs"]["release_token"]["required"] is False
 
     # Verify it's a composite action
     assert action["runs"]["using"] == "composite"

--- a/tests/test_calver_auto_release.py
+++ b/tests/test_calver_auto_release.py
@@ -193,6 +193,53 @@ def test_format_release_notes(git_repo: git.Repo) -> None:
     assert "**3** contributors" in notes_with_repo  # Test User + John Doe + Jane Doe
 
 
+def test_format_release_notes_links_github_commits(git_repo: git.Repo) -> None:
+    """Test that GitHub remotes produce linked commit entries."""
+    git_repo.remote("origin").set_url("git@github.com:example/project.git")
+
+    notes = _format_release_notes(
+        "Initial commit",
+        "v2024.1.0",
+        "",
+        repo=git_repo,
+    )
+
+    commit_hash = git_repo.head.commit.hexsha[:7]
+    assert f"https://github.com/example/project/commit/{commit_hash}" in notes
+    assert "[Initial commit]" in notes
+
+
+def test_format_release_notes_without_remote(git_repo: git.Repo) -> None:
+    """Test release notes formatting when no origin remote exists."""
+    git_repo.delete_remote("origin")
+
+    notes = _format_release_notes(
+        "Initial commit",
+        "v2024.1.0",
+        "",
+        repo=git_repo,
+    )
+
+    assert "- Initial commit" in notes
+
+
+def test_format_release_notes_falls_back_on_git_log_error(git_repo_with_tag: git.Repo) -> None:
+    """Test fallback to simple commit messages when detailed git log fails."""
+    with patch(
+        "calver_auto_release._get_commit_details",
+        side_effect=git.exc.GitCommandError("git log", 1),
+    ):
+        notes = _format_release_notes(
+            "Fallback commit",
+            "v2024.1.0",
+            "",
+            repo=git_repo_with_tag,
+        )
+
+    assert "- Fallback commit" in notes
+    assert "**1** commits" in notes
+
+
 def test_should_skip_release(git_repo: git.Repo) -> None:
     """Test skip release detection."""
     for pattern in DEFAULT_SKIP_PATTERNS:


### PR DESCRIPTION
## Summary

- add an optional `release_token` input for tag push and GitHub release creation
- keep `github_token` as the backwards-compatible default
- document when a PAT or GitHub App token is needed so downstream `push`, `create`, or `release` workflows can run

## Validation

- `uv run --extra test pytest`