### PR TITLE
Configure Codecov patch status only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+# Pytest already enforces whole-project coverage with --cov-fail-under.
+# Keep Codecov's required signal focused on coverage for changed lines.
+coverage:
+  status:
+    project: off
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
## Summary

- add a root `codecov.yml`
- disable Codecov's blocking `project` status
- keep the `patch` status so changed lines still need coverage

## Why

The repo already enforces whole-project coverage in pytest via `--cov-fail-under=90`. The Codecov `project` check compares total coverage against the PR base, which has been blocking dependency-only Renovate PRs even when their patch coverage is green. Keeping Codecov focused on `patch` coverage preserves the useful PR signal without duplicating the pytest project coverage gate.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file("codecov.yml"); puts "yaml ok"'`
- `git diff --cached --check`