### PR TITLE
Fix exact CalVer tag selection

### DIFF
--- a/calver_auto_release.py
+++ b/calver_auto_release.py
@@ -7,13 +7,14 @@ GitHub releases with automatically generated release notes.
 
 from __future__ import annotations
 
+import argparse
 import datetime
-import operator
 import os
+import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import git
-from packaging import version
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
@@ -28,8 +29,19 @@ DEFAULT_FOOTER = (
     "\n\n🙏 Thank you for using this project! Please report any issues "
     "or feedback on the GitHub repository."
 )
+RELEASE_TAG_RE = re.compile(r"^v(?P<year>\d{4})\.(?P<month>0?[1-9]|1[0-2])\.(?P<patch>\d+)$")
 
 console = Console(soft_wrap=True)
+
+
+@dataclass(frozen=True)
+class ReleaseTag:
+    """Parsed exact CalVer release tag."""
+
+    name: str
+    year: int
+    month: int
+    patch: int
 
 
 def create_release(
@@ -134,8 +146,11 @@ def _display_release_info(
 
 
 def _is_already_tagged(repo: git.Repo) -> bool:
-    """Check if the current commit is already tagged."""
-    return bool(repo.git.tag(points_at="HEAD"))
+    """Check if the current commit already has an exact release tag."""
+    return any(
+        _parse_release_tag(tag_name) is not None
+        for tag_name in repo.git.tag(points_at="HEAD").splitlines()
+    )
 
 
 def _should_skip_release(repo: git.Repo, skip_patterns: Sequence[str]) -> bool:
@@ -144,26 +159,60 @@ def _should_skip_release(repo: git.Repo, skip_patterns: Sequence[str]) -> bool:
     return any(pattern in commit_message for pattern in skip_patterns)
 
 
-def _get_new_version(repo: git.Repo) -> str:
+def _parse_release_tag(tag_name: str) -> ReleaseTag | None:
+    """Parse an exact CalVer release tag."""
+    match = RELEASE_TAG_RE.match(tag_name)
+    if match is None:
+        return None
+    return ReleaseTag(
+        name=tag_name,
+        year=int(match.group("year")),
+        month=int(match.group("month")),
+        patch=int(match.group("patch")),
+    )
+
+
+def _all_exact_release_tags(repo: git.Repo) -> list[ReleaseTag]:
+    """Return all tags that exactly match the CalVer release format."""
+    return [
+        release_tag
+        for tag in repo.tags
+        if (release_tag := _parse_release_tag(tag.name)) is not None
+    ]
+
+
+def _tag_commit_is_ancestor(repo: git.Repo, tag_name: str) -> bool:
+    """Return whether a tag's target commit is reachable from HEAD."""
+    try:
+        repo.git.merge_base("--is-ancestor", f"{tag_name}^{{}}", "HEAD")
+    except git.exc.GitCommandError:
+        return False
+    return True
+
+
+def _latest_reachable_release_tag(repo: git.Repo) -> ReleaseTag | None:
+    """Return the highest exact release tag reachable from HEAD."""
+    reachable_tags = [
+        tag for tag in _all_exact_release_tags(repo) if _tag_commit_is_ancestor(repo, tag.name)
+    ]
+    if not reachable_tags:
+        return None
+    return max(reachable_tags, key=lambda tag: (tag.year, tag.month, tag.patch))
+
+
+def _get_new_version(repo: git.Repo, today: datetime.date | None = None) -> str:
     """Get the new version number.
 
     Returns a version string in the format vYYYY.MM.PATCH, e.g., v2024.3.1
     """
-    try:
-        latest_tag = max(repo.tags, key=operator.attrgetter("commit.committed_datetime"))
-        # Remove 'v' prefix for version parsing
-        last_version = version.parse(latest_tag.name.lstrip("v"))
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
-        patch = (
-            last_version.micro + 1
-            if last_version.major == now.year and last_version.minor == now.month
-            else 0
-        )
-    except ValueError:  # No tags exist
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
-        patch = 0
+    today = today or datetime.datetime.now(tz=datetime.timezone.utc).date()
+    release_tags = _all_exact_release_tags(repo)
+    current_month_patches = [
+        tag.patch for tag in release_tags if tag.year == today.year and tag.month == today.month
+    ]
+    patch = max(current_month_patches, default=-1) + 1
 
-    return f"v{now.year}.{now.month}.{patch}"
+    return f"v{today.year}.{today.month}.{patch}"
 
 
 def _set_author(repo: git.Repo) -> None:
@@ -194,11 +243,10 @@ def _push_tag(repo: git.Repo, new_version: str) -> None:
 
 def _get_commit_messages_since_last_release(repo: git.Repo) -> str:
     """Get the commit messages since the last release."""
-    try:
-        latest_tag = max(repo.tags, key=operator.attrgetter("commit.committed_datetime"))
-        return repo.git.log(f"{latest_tag}..HEAD", "--pretty=format:%s")  # type: ignore[no-any-return]
-    except ValueError:  # No tags exist
+    latest_tag = _latest_reachable_release_tag(repo)
+    if latest_tag is None:
         return repo.git.log("--pretty=format:%s")  # type: ignore[no-any-return]
+    return repo.git.log(f"{latest_tag.name}..HEAD", "--pretty=format:%s")  # type: ignore[no-any-return]
 
 
 def _get_commit_details(repo: git.Repo, since_ref: str | None = None) -> list[tuple[str, str, str]]:
@@ -243,8 +291,7 @@ def _format_release_notes(
     if repo is not None:
         try:
             remote_url = repo.remote("origin").url
-            if remote_url.endswith(".git"):
-                remote_url = remote_url[:-4]
+            remote_url = remote_url.removesuffix(".git")
             if "github.com" in remote_url:
                 repo_url = remote_url.replace("git@github.com:", "https://github.com/")
         except (git.exc.GitCommandError, ValueError):
@@ -256,10 +303,11 @@ def _format_release_notes(
     unique_authors = set()
     if repo is not None:
         try:
-            latest_tag = max(repo.tags, key=operator.attrgetter("commit.committed_datetime"))
-            commits_info = _get_commit_details(repo, latest_tag.name)
-        except ValueError:  # No tags exist
-            commits_info = _get_commit_details(repo)
+            latest_tag = _latest_reachable_release_tag(repo)
+            commits_info = _get_commit_details(
+                repo,
+                latest_tag.name if latest_tag is not None else None,
+            )
         except git.exc.GitCommandError:
             # Fallback to simple commit messages if git commands fail
             commits_info = [("", "", msg) for msg in commit_messages.split("\n") if msg]
@@ -309,8 +357,6 @@ def _format_release_notes(
 
 def cli() -> None:
     """Command-line interface for calver-auto-release."""
-    import argparse
-
     parser = argparse.ArgumentParser(description="Create a new release with CalVer format.")
     parser.add_argument(
         "--repo-path",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Version Control :: Git",
 ]
-dependencies = ["gitpython>=3.1.0", "packaging>=23.0", "rich>=13.0.0"]
+dependencies = ["gitpython>=3.1.0", "rich>=13.0.0"]
 
 [project.optional-dependencies]
 test = [

--- a/tests/test_calver_auto_release.py
+++ b/tests/test_calver_auto_release.py
@@ -15,6 +15,7 @@ from calver_auto_release import (
     DEFAULT_FOOTER,
     DEFAULT_SKIP_PATTERNS,
     _format_release_notes,
+    _get_commit_messages_since_last_release,
     _get_new_version,
     _should_skip_release,
     cli,
@@ -50,9 +51,18 @@ def git_repo(tmp_path: Path) -> git.Repo:
 def git_repo_with_tag(git_repo: git.Repo) -> git.Repo:
     """Create a temporary git repository with a tag."""
     now = datetime.datetime.now(tz=datetime.timezone.utc)
-    tag_name = f"{now.year}.{now.month}.0"
+    tag_name = f"v{now.year}.{now.month}.0"
     git_repo.create_tag(tag_name, message=f"Release {tag_name}")
     return git_repo
+
+
+def _commit_file(repo: git.Repo, message: str) -> None:
+    """Append to a tracked file and commit it."""
+    history = Path(repo.working_dir) / "history.txt"
+    existing = history.read_text() if history.exists() else ""
+    history.write_text(f"{existing}{message}\n")
+    repo.index.add([str(history)])
+    repo.index.commit(message)
 
 
 def test_create_release_basic(git_repo: git.Repo) -> None:
@@ -104,6 +114,15 @@ def test_create_release_already_tagged(git_repo_with_tag: git.Repo) -> None:
     """Test when commit is already tagged."""
     version = create_release(repo_path=git_repo_with_tag.working_dir)
     assert version is None
+
+
+def test_create_release_ignores_non_release_tag_on_head(git_repo: git.Repo) -> None:
+    """Test that non-CalVer tags on HEAD do not block a release."""
+    git_repo.create_tag("build-artifact")
+
+    version = create_release(repo_path=git_repo.working_dir, dry_run=True)
+
+    assert version is not None
 
 
 def test_create_release_custom_footer(git_repo: git.Repo) -> None:
@@ -255,6 +274,58 @@ def test_get_new_version_no_tags(git_repo: git.Repo) -> None:
     version = _get_new_version(git_repo)
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     assert version == f"v{now.year}.{now.month}.0"
+
+
+def test_get_new_version_ignores_branch_specific_tags(git_repo: git.Repo) -> None:
+    """Branch-specific tags must not reset the patch counter or release boundary."""
+    base_branch = git_repo.active_branch.name
+
+    git_repo.create_tag("v2026.6.142", message="Release v2026.6.142")
+    _commit_file(git_repo, "Make SaaS API type check portable (#1287)")
+    git_repo.create_tag("v2026.6.143", message="Release v2026.6.143")
+
+    git_repo.git.checkout("-b", "hotfix/sso-cookie-domain")
+    _commit_file(git_repo, "Regenerate SaaS API schema for SSO hotfix")
+    git_repo.create_tag("v2026.6.142-sso-cookie.2")
+    git_repo.git.checkout(base_branch)
+
+    _commit_file(git_repo, "List unstructured file memories (#1286)")
+
+    version = _get_new_version(git_repo, today=datetime.date(2026, 6, 15))
+    commit_messages = _get_commit_messages_since_last_release(git_repo)
+
+    assert version == "v2026.6.144"
+    assert "List unstructured file memories (#1286)" in commit_messages
+    assert "Make SaaS API type check portable (#1287)" not in commit_messages
+    assert "Regenerate SaaS API schema for SSO hotfix" not in commit_messages
+
+
+def test_get_new_version_skips_exact_tag_from_unmerged_branch(git_repo: git.Repo) -> None:
+    """A release candidate must never collide with any exact CalVer tag."""
+    base_branch = git_repo.active_branch.name
+
+    git_repo.create_tag("v2026.6.143", message="Release v2026.6.143")
+    git_repo.git.checkout("-b", "release-candidate")
+    _commit_file(git_repo, "Candidate build")
+    git_repo.create_tag("v2026.6.144")
+    git_repo.git.checkout(base_branch)
+    _commit_file(git_repo, "Mainline fix")
+
+    version = _get_new_version(git_repo, today=datetime.date(2026, 6, 15))
+    commit_messages = _get_commit_messages_since_last_release(git_repo)
+
+    assert version == "v2026.6.145"
+    assert "Mainline fix" in commit_messages
+    assert "Candidate build" not in commit_messages
+
+
+def test_get_new_version_handles_zero_padded_existing_tag(git_repo: git.Repo) -> None:
+    """Zero-padded month tags should still reserve their parsed version tuple."""
+    git_repo.create_tag("v2026.06.1", message="Release v2026.06.1")
+
+    version = _get_new_version(git_repo, today=datetime.date(2026, 6, 15))
+
+    assert version == "v2026.6.2"
 
 
 def test_cli(git_repo: git.Repo, capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
## Summary

- only treat exact `vYYYY.M.PATCH` / `vYYYY.MM.PATCH` tags as release tags
- ignore suffixed branch-specific tags for release boundaries and already-tagged checks
- avoid collisions with exact CalVer tags anywhere in the repo, including unmerged branches
- remove the now-unused `packaging` runtime dependency

## Why

MindRoom hit a release failure when branch-specific tags such as `v2026.6.142-sso-cookie.2` interfered with patch selection / release-note boundaries. This moves the fix into `calver-auto-release` so consumers do not need local release scripts.

## Validation

- `uv run --extra test pytest --cov-report term-missing`
- `uv run ruff check calver_auto_release.py tests/test_calver_auto_release.py pyproject.toml`